### PR TITLE
Add a .gitignore to ignore build directories and VSCode configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode/
+bin/
+obj/


### PR DESCRIPTION
Allow users to build in-source without worrying about build directories being added to the repo.